### PR TITLE
Removed  `--no-progress` option

### DIFF
--- a/Content/applicationHost.xdt
+++ b/Content/applicationHost.xdt
@@ -12,7 +12,7 @@
     <runtime xdt:Transform="Insert">
          <environmentVariables>
             <add name="APPSETTING_COMMAND" value="d:\home\SiteExtensions\ComposerExtension\Hooks\deploy.cmd" />
-	    <add name="COMPOSER_ARGS" value="--prefer-dist --no-dev --optimize-autoloader --no-progress" />
+	    <add name="COMPOSER_ARGS" value="--prefer-dist --no-dev --optimize-autoloader" />
             <add name="PATH" value="%PATH%;d:\home\SiteExtensions\ComposerExtension\Commands;%APPDATA%\Composer\vendor\bin" />
          </environmentVariables>
     </runtime>


### PR DESCRIPTION
The option  `--no-progress` have been removed so you can see what happen in a deploy and also fix the problem of command timeout without output.
