### PR TITLE
Denying access to the path starting with `/vendor/`

### DIFF
--- a/Content/applicationHost.xdt
+++ b/Content/applicationHost.xdt
@@ -21,7 +21,7 @@
         <rule name="RequestBlockingRule1" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" stopProcessing="true">
                     <match url=".*" />
                     <conditions>
-                        <add input="{URL}" pattern="vendor/(.*)$" />
+                        <add input="{URL}" pattern="^/vendor/(.*)$" />
                     </conditions>
                     <action type="CustomResponse" statusCode="403" statusReason="Forbidden: Access is denied." statusDescription="You do not have permission to view this directory or page using the credentials that you supplied." />
                 </rule>


### PR DESCRIPTION
The previous condition for prohibiting access to composer's vendor covered other deeper directories like `fonts/vendor/bootstrap-sass/bootstrap/glyphicons-halflings-regular.woff2`, this path is actually generated by Laravel-mix.

This PR aims to relax and make this condition focus on prohibiting the directory generated by composer. 